### PR TITLE
refactored linkall script

### DIFF
--- a/scripts/linkall.sh
+++ b/scripts/linkall.sh
@@ -1,52 +1,38 @@
 #!/bin/sh
 
+set -e
+
 # You probably don't want this! Just use npm install, and later
 # npm update to stay up to date with our modules. We use this script
 # to "npm link" all of the modules that we maintain so we can do
 # active development on them. You must have a ${HOME}/src folder in which
 # they may be `git clone`d.
 
+grep -q '"apostrophe": "' package.json || (echo "\nThis project doesn't seem to depend on apostrophe, are you in the right directory?\n" && exit 1)
+
 # Load the official list of modules we're maintaining
 source scripts/our-modules.source
 
-mkdir -p ${HOME}/src || exit 1
+projectPath=`pwd`
+project=`basename $projectPath`
+aposDir=${HOME}/src/apostrophe
 
-# 1. Clone the modules that aren't already out there
+mkdir -p $aposDir
 
-echo "Cloning modules not already present"
+echo ""
+echo "Preparing $projectPath for development"
+echo ""
 
-for module in "${modules[@]}"
-  do
-    if [ ! -d "${HOME}/src/${module}" ]; then
-      ( echo "Checking out ${module} and registering it for npm link" && cd ${HOME}/src && git clone "http://github.com/punkave/${module}" && cd ${module} && npm install && npm link ) || exit 1
-    fi
-  done
+for module in "${modules[@]}"; do
+  modDir="$aposDir/$module"
 
-# 2. Establish npm links *between* modules that depend on each other
+  # Checkout the module if it hasn't been setup yet
+  [ ! -d $modDir ] && (
+    echo "Checking out $module into $modDir"
+    git clone -q "git@github.com:punkave/$module.git" $modDir
+  )
 
-echo "Establishing npm links *between* modules"
+  echo "\n --> Setting up $module in $project\n"
+  npm link $modDir --silent # Global & local links and install deps
 
-for module in "${modules[@]}"
-  do
-    for submodule in "${modules[@]}"
-      do
-        mdir="${HOME}/src/${module}"
-        # If the module is currently a subdir of another module make it a link instead
-        if [ -d "${mdir}/node_modules/${submodule}" ]; then
-          ( echo "Sub-linking ${submodule} for ${module}" && cd $mdir && npm link ${submodule} ) || exit 1
-        fi
-      done
-  done
-
-# 3. npm link from the project
-
-echo "Establishing npm links in the *project*"
-
-for module in "${modules[@]}"
-  do
-    if [ ! -h "node_modules/${module}" ]; then
-      ( echo "Linking ${module}" && npm link ${module} ) || exit 1
-    fi
-  done
-
-
+done


### PR DESCRIPTION
You were doing a little bit of extra work in this script so I simplified things a little. 

If you run `npm link ../<module dir>` inside of your project, it will automatically create a global link, local link and make sure to run `npm install`. See the bottom of https://npmjs.org/doc/link.html

Also, You only need to do this at the project level, and not in each module, because require will always check the root `node_modules`, even in modules farther down. See https://npmjs.org/doc/dedupe.html for more info. 

Finally, I made a **bold** assumption here. I like everything in `~/src` like had originally setup.  I would like to setup the practice of having all the apostrophe modules in `~/src/apostrophe` folder (see line 18). This keeps `src` a little tidier and make it really easy to open up everything in one sublime window (`cd ~/src/apostrophe; subl .`)
